### PR TITLE
Fix version displayed on command line

### DIFF
--- a/libexec/jenv---version
+++ b/libexec/jenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
-version="0.4.0"
+version="0.4.2"
 
 if [ -d $JENV_ROOT ]; then
 cd "$JENV_ROOT"


### PR DESCRIPTION
The latest version is 0.4.2 but `jenv --version` is still displaying
0.4.0.