### PR TITLE
Add shim for fsc to scala plugin

### DIFF
--- a/available-plugins/scala/etc/jenv.d/rehash/scala.bash
+++ b/available-plugins/scala/etc/jenv.d/rehash/scala.bash
@@ -5,12 +5,14 @@ backuppath=$PATH
 PATH="$(remove_from_path "${JENV_ROOT}/shims")"
 SCALA_BIN="$(command -v "scala" || true)"
 SCALAC_BIN="$(command -v "scalac" || true)"
+FSC_BIN="$(command -v "fsc" || true)"
 
 
 PATH=$backuppath
 
 make_shims "$SCALA_BIN"    
 make_shims "$SCALAC_BIN"  
+make_shims "$FSC_BIN"
 
 
 


### PR DESCRIPTION
Add a shim for fsc, the fast Scala compiler, which comes with
standard Scala installations.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gcuisinier/jenv/88)
<!-- Reviewable:end -->
