### PR TITLE
fix version returned by jenv --version

### DIFF
--- a/libexec/jenv---version
+++ b/libexec/jenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
-version="0.4.2"
+version="0.4.3"
 
 if [ -d $JENV_ROOT ]; then
 cd "$JENV_ROOT"


### PR DESCRIPTION
Hi Gildas,

The homebrew formula is ready, but I'd rather have the version returned by `jenv --version` correspond to the tag.

Thanks!
Romain