### PR TITLE
Don't run jenv javahome twice

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
@@ -7,7 +7,7 @@
 
   if [ -e "$JAVA_HOME/bin/javac" ]
   then
-    export JDK_HOME=$(jenv javahome)
+    export JDK_HOME="$JAVA_HOME"
     export JENV_FORCEJDKHOME=true
   fi
    }


### PR DESCRIPTION
The second call to "jenv javahome" to set JDK_HOME is unnecessary. It
adds 60ms on my system.