### PR TITLE
Don't define JENV_DIR from the 1st 'java' file param

### DIFF
--- a/libexec/jenv-rehash
+++ b/libexec/jenv-rehash
@@ -78,19 +78,6 @@ set -e
 [ -n "\$JENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
-if [ "\$program" = "java" ]; then
-  for arg; do
-    case "\$arg" in
-    -e* | -- ) break ;;
-    */* )
-      if [ -f "\$arg" ]; then
-        export JENV_DIR="\${arg%/*}"
-        break
-      fi
-      ;;
-    esac
-  done
-fi
 
 export JENV_ROOT="$JENV_ROOT"
 exec "$(command -v jenv)" exec "\$program" "\$@"


### PR DESCRIPTION
This logic originates from one of the first ever commits of jenv:
c6819eaf6a60dc4e8ba1cb2de48dfb9eba4547b0.

I'm not sure what justifies this behaviour, but there have been at least
two issues reporting this as breaking expectations: #151 and #162.

So I'm proposing removing it with this patch.

Fixes #151. Fixes #162.