### PR TITLE
Always add java bin directory to PATH in jenv-exec

### DIFF
--- a/libexec/jenv-exec
+++ b/libexec/jenv-exec
@@ -41,7 +41,6 @@ if [ -z "$JENV_COMMAND" ]; then
 fi
 
 JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")"
-JENV_BIN_PATH="${JENV_COMMAND_PATH%/*}"
 
 for script in $(jenv-hooks exec); do
 
@@ -50,6 +49,6 @@ done
 
 shift 1
 if [ "$JENV_VERSION" != "system" ]; then
-  export PATH="${JENV_BIN_PATH}:${PATH}"
+  export PATH="${JAVA_HOME}/bin:${PATH}"
 fi
 exec -a "$JENV_COMMAND" "$JENV_COMMAND_PATH" $JENV_OPTIONS "$@"


### PR DESCRIPTION
The jenv exec command should prepend the path to the selected Java
version's bin directory to the PATH for the command being executed. The
command to be executed, however, is not necessarily a Java interpreter -
for example, the Maven plugin passes in /usr/local/bin/mvn. Therefore
the selected Java version's bin directory should not be determined from
the command, but from JAVA_HOME.