### PR TITLE
Update getting started fish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Verified on :
 
 	_Same as in previous step, use `~/.profile` on Ubuntu, `~/.zshrc` for Zsh._
 
-    **Fish note**: Instead, copy `jenv.fish` to yor fish functions folder. If you don't have the `export` function, also copy `export.fish`
+    **Fish note**: Instead, copy `jenv.fish` to your fish functions folder. If you don't have the `export` function, also copy `export.fish`
     ~~~ sh
-        cp /usr/local/Cellar/jenv/0.4.4/libexec/fish/jenv.fish ~/.config/fish/functions/jenv.fish
-        cp /usr/local/Cellar/jenv/0.4.4/libexec/fish/export.fish ~/.config/fish/functions/export.fish
+        cp ~/.jenv/fish/jenv.fish ~/.config/fish/functions/jenv.fish
+        cp ~/.jenv/fish/export.fish ~/.config/fish/functions/export.fish
     ~~~
 
 4. Restart your shell as a login shell so the path changes take effect. You can now begin using jenv.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Verified on :
 
 	_Same as in previous step, use `~/.profile` on Ubuntu, `~/.zshrc` for Zsh._
 
-    **Fish note**: Instead, copy `~/.jenv/fish/jenv.fish` to `~/.conf/fish/function/jenv.fish`. If you don't have the `export` function, also copy `export.fish`
+    **Fish note**: Instead, copy `jenv.fish` to yor fish functions folder. If you don't have the `export` function, also copy `export.fish`
     ~~~ sh
-        cp ~/.jenv/fish/jenv.fish ~/.conf/fish/function/jenv.fish
-        cp ~/.jenv/fish/export.fish ~/.conf/fish/function/export.fish
+        cp /usr/local/Cellar/jenv/0.4.4/libexec/fish/jenv.fish ~/.config/fish/functions/jenv.fish
+        cp /usr/local/Cellar/jenv/0.4.4/libexec/fish/export.fish ~/.config/fish/functions/export.fish
     ~~~
 
 4. Restart your shell as a login shell so the path changes take effect. You can now begin using jenv.


### PR DESCRIPTION
For me both sides of the copy function differed from my Mac OS Mojave setup with jenv installed via Brew. Possible issues with this PR:

- It's brew specific 
  - Anyone know why my ~/.jenv/ folder didn't include a fish folder?
- It's tied to the current jenv version
- The paths may be brew and Mac specific